### PR TITLE
Fix 'Core software requirments' table

### DIFF
--- a/_source/setup/software_packages.csv
+++ b/_source/setup/software_packages.csv
@@ -1,4 +1,4 @@
 Software Package,Notes
-Webserver,Apache version 2.4  or NGINX 1.14 or later are recommended.
-MYSQL Database,Versions 5.7 and 8.0 are supported. Equivalent versions of MariaDB will also work.
-PHP programming language,PHP version 7.2 or better is required. PHP 7.3 or 7.4 is strongly recommended. Note that PHP 8 is not yet supported, but will be soon.
+Webserver,`Apache`_ version 2.4  or `nginx`_ 1.14 or later are recommended.
+`MySQL`_ Database,Versions 5.7 and 8.0 are supported. Equivalent versions of `MariaDB`_ will also work.
+`PHP`_ programming language,`PHP`_ version 7.2 or better is required. PHP 7.3 or 7.4 is strongly recommended. Note that PHP 8 is not yet supported. This is planned soon.

--- a/_source/setup/systemReq.rst
+++ b/_source/setup/systemReq.rst
@@ -31,8 +31,10 @@ Providence requires three core open-source software packages be installed prior 
    :file: software_packages.csv
 
 .. _PHP: https://php.net/
-.. _Apache or nginx: https://httpd.apache.org/ or https://nginx.org
+.. _Apache: https://httpd.apache.org/
+.. _nginx: https://httpd.apache.org/ or https://nginx.org
 .. _MySQL: https://dev.mysql.com/
+.. _MariaDB: https://mariadb.org/
 
 All of these should be available as pre-compiled packages for most Linux distributions and as installer packages for Windows. For Macs, `Brew`_ is a highly recommended way to get all of CA's prerequisites quickly up and running.
 


### PR DESCRIPTION
It was not rendered because a ',' in the PHP column was misinterpreted
as a column separator, and no links were added.