### PR TITLE
Add prerequisites to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This repository contains documentation for the CollectiveAccess [Providence](https://github.com/collectiveaccess/Providence) collections management application. An HTML-rendered version of the manual can be accesed on  https://manual.collectiveaccess.org/
 
-For compiling documentation try  `pip3 install sphinx` and than in `_source` directory run `make html`
+For compiling documentation try  `pip3 install sphinx sphinx-rtd-theme sphinxcontrib-excel-table` and than in `_source` directory run `make html`
 
 
 


### PR DESCRIPTION
Documentation will not comple in vanilla sphinx, you need two plugins. 